### PR TITLE
Update instructions to reference local dataset (2_NaiveBayes)

### DIFF
--- a/lessons/Supervised/2_NaiveBayes/Bayesian_Inference.ipynb
+++ b/lessons/Supervised/2_NaiveBayes/Bayesian_Inference.ipynb
@@ -57,8 +57,7 @@
     "### Step 1.1: Understanding our dataset ### \n",
     "\n",
     "\n",
-    "We will be using a [dataset](https://archive.ics.uci.edu/ml/datasets/SMS+Spam+Collection) from the UCI Machine Learning repository which has a very good collection of datasets for experimental research purposes. The direct data link is [here](https://archive.ics.uci.edu/ml/machine-learning-databases/00228/).\n",
-    "\n",
+    "We will be using a dataset originally compiled and posted on the UCI Machine Learning repository which has a very good collection of datasets for experimental research purposes. If you're interested, you can review the [abstract](https://archive.ics.uci.edu/ml/datasets/SMS+Spam+Collection) and the original [compressed data file](https://archive.ics.uci.edu/ml/machine-learning-databases/00228/) on the UCI site. For this exercise, however, we've gone ahead and downloaded the data for you.\n",
     "\n",
     " ** Here's a preview of the data: ** \n",
     "\n",
@@ -78,7 +77,7 @@
    },
    "source": [
     ">** Instructions: **\n",
-    "* Import the dataset into a pandas dataframe using the read_table method. Because this is a tab separated dataset we will be using '\\t' as the value for the 'sep' argument which specifies this format. \n",
+    "* Import the dataset into a pandas dataframe using the read_table method. The file has already been downloaded, and you can access it using the filepath 'smsspamcollection/SMSSpamCollection'. Because this is a tab separated dataset we will be using '\\t' as the value for the 'sep' argument which specifies this format. \n",
     "* Also, rename the column names by specifying a list ['label, 'sms_message'] to the 'names' argument of read_table().\n",
     "* Print the first five values of the dataframe with the new column names."
    ]
@@ -93,7 +92,7 @@
     "Solution\n",
     "'''\n",
     "import pandas as pd\n",
-    "# Dataset from - https://archive.ics.uci.edu/ml/datasets/SMS+Spam+Collection\n",
+    "# Dataset available using filepath 'smsspamcollection/SMSSpamCollection'\n",
     "df = #TODO\n",
     "\n",
     "# Output printing out first 5 columns\n",

--- a/lessons/Supervised/2_NaiveBayes/Bayesian_Inference_solution.ipynb
+++ b/lessons/Supervised/2_NaiveBayes/Bayesian_Inference_solution.ipynb
@@ -39,8 +39,7 @@
     "### Step 1.1: Understanding our dataset ### \n",
     "\n",
     "\n",
-    "We will be using a [dataset](https://archive.ics.uci.edu/ml/datasets/SMS+Spam+Collection) from the UCI Machine Learning repository which has a very good collection of datasets for experimental research purposes. The direct data link is [here](https://archive.ics.uci.edu/ml/machine-learning-databases/00228/).\n",
-    "\n",
+    "We will be using a dataset originally compiled and posted on the UCI Machine Learning repository which has a very good collection of datasets for experimental research purposes. If you're interested, you can review the [abstract](https://archive.ics.uci.edu/ml/datasets/SMS+Spam+Collection) and the original [compressed data file](https://archive.ics.uci.edu/ml/machine-learning-databases/00228/) on the UCI site. For this exercise, however, we've gone ahead and downloaded the data for you.\n",
     "\n",
     " ** Here's a preview of the data: ** \n",
     "\n",
@@ -60,7 +59,7 @@
    },
    "source": [
     ">** Instructions: **\n",
-    "* Import the dataset into a pandas dataframe using the read_table method. Because this is a tab separated dataset we will be using '\\t' as the value for the 'sep' argument which specifies this format. \n",
+    "* Import the dataset into a pandas dataframe using the read_table method. The file has already been downloaded, and you can access it using the filepath 'smsspamcollection/SMSSpamCollection'. Because this is a tab separated dataset we will be using '\\t' as the value for the 'sep' argument which specifies this format. \n",
     "* Also, rename the column names by specifying a list ['label, 'sms_message'] to the 'names' argument of read_table().\n",
     "* Print the first five values of the dataframe with the new column names."
    ]
@@ -131,7 +130,7 @@
     "Solution\n",
     "'''\n",
     "import pandas as pd\n",
-    "# Dataset from - https://archive.ics.uci.edu/ml/datasets/SMS+Spam+Collection\n",
+    "# Dataset available using filepath 'smsspamcollection/SMSSpamCollection'\n",
     "df = pd.read_table('smsspamcollection/SMSSpamCollection',\n",
     "                   sep='\\t', \n",
     "                   header=None, \n",


### PR DESCRIPTION
The instructions for this exercise haven't been updated to reference
the local uncompressed copy of the SMS Spam Collection dataset from
the UCI ML library. Attempting to use the instructions as-is simply
reads HTML headers from the directory.

Note: This is correctly referenced in the later Ensemble Methods lesson.