### PR TITLE
Fixed markdown for table summarizing DBSCAN's params

### DIFF
--- a/lessons/Unsupervised/2_HierarchcalDensityClustering/DBSCAN Notebook [SOLUTION].ipynb
+++ b/lessons/Unsupervised/2_HierarchcalDensityClustering/DBSCAN Notebook [SOLUTION].ipynb
@@ -337,8 +337,8 @@
     "## Heuristics for experimenting with DBSCAN's parameters\n",
     "Looking at this grid, we can guess at some general heuristics for tweaking the parameters of DBSCAN:\n",
     "\n",
-    "| |Epsilon too low|Epsilon too high|\n",
-    "|---|---|---|---|\n",
+    "|Parameters|Epsilon too low|Epsilon too high|\n",
+    "|---|---|---|\n",
     "|**min_samples too low** |<img src='images/low_epsilon_and_low_min_sample.png'><br>Many small clusters. More than anticipated for the dataset. <br>**Action**: increase min_samples and epsilon| <img src='images/high_epsilon_and_low_min_sample.png'><br>Most points belong to one cluster<br>**Action**: decrease epsilon and increase min_samples|\n",
     "|**min_samples too high**|<img src='images/low_epsilon_and_high_min_sample.png'><br>Most/all data points are labeled as noise<br>**Action**: increase epsilon and decrease min_sample| <img src='images/high_epsilon_and_high_min_sample.png'><br> Except for extremely dense regions, most/all data points are <br>labeled as noise. (Or all points are labeled as noise). <br>**Action**: decrease min_samples and epsilon.|"
    ]

--- a/lessons/Unsupervised/2_HierarchcalDensityClustering/DBSCAN Notebook.ipynb
+++ b/lessons/Unsupervised/2_HierarchcalDensityClustering/DBSCAN Notebook.ipynb
@@ -251,8 +251,8 @@
     "## Heuristics for experimenting with DBSCAN's parameters\n",
     "Looking at this grid, we can guess at some general heuristics for tweaking the parameters of DBSCAN:\n",
     "\n",
-    "| |Epsilon too low|Epsilon too high|\n",
-    "|---|---|---|---|\n",
+    "|Parameters|Epsilon too low|Epsilon too high|\n",
+    "|---|---|---|\n",
     "|**min_samples too low** |<img src='images/low_epsilon_and_low_min_sample.png'><br>Many small clusters. More than anticipated for the dataset. <br>**Action**: increase min_samples and epsilon| <img src='images/high_epsilon_and_low_min_sample.png'><br>Most points belong to one cluster<br>**Action**: decrease epsilon and increase min_samples|\n",
     "|**min_samples too high**|<img src='images/low_epsilon_and_high_min_sample.png'><br>Most/all data points are labeled as noise<br>**Action**: increase epsilon and decrease min_sample| <img src='images/high_epsilon_and_high_min_sample.png'><br> Except for extremely dense regions, most/all data points are <br>labeled as noise. (Or all points are labeled as noise). <br>**Action**: decrease min_samples and epsilon.|"
    ]


### PR DESCRIPTION
### Currently, table shows up as:

<img width="506" alt="before" src="https://user-images.githubusercontent.com/12243123/53595537-6509aa00-3b52-11e9-903c-a5dbb9274986.png">

### Fixed to:

<img width="1018" alt="after" src="https://user-images.githubusercontent.com/12243123/53595540-676c0400-3b52-11e9-9c16-cf6bb2deac9e.png">
