### PR TITLE
Fix copy-paste error in cell doc

### DIFF
--- a/lessons/DeepLearning/new-intro-to-pytorch/Part 1 - Tensors in PyTorch (Exercises).ipynb
+++ b/lessons/DeepLearning/new-intro-to-pytorch/Part 1 - Tensors in PyTorch (Exercises).ipynb
@@ -93,7 +93,7 @@
     "### Generate some data\n",
     "torch.manual_seed(7) # Set the random seed so things are predictable\n",
     "\n",
-    "# Features are 3 random normal variables\n",
+    "# Features are 5 random normal variables\n",
     "features = torch.randn((1, 5))\n",
     "# True weights for our data, random normal variables again\n",
     "weights = torch.randn_like(features)\n",

--- a/lessons/DeepLearning/new-intro-to-pytorch/Part 1 - Tensors in PyTorch (Solution).ipynb
+++ b/lessons/DeepLearning/new-intro-to-pytorch/Part 1 - Tensors in PyTorch (Solution).ipynb
@@ -93,7 +93,7 @@
     "### Generate some data\n",
     "torch.manual_seed(7) # Set the random seed so things are predictable\n",
     "\n",
-    "# Features are 3 random normal variables\n",
+    "# Features are 5 random normal variables\n",
     "features = torch.randn((1, 5))\n",
     "# True weights for our data, random normal variables again\n",
     "weights = torch.randn_like(features)\n",


### PR DESCRIPTION
Fixing copy-paste error. In first piece of exercise, there are 5 random variables, not 3 as occurs later in the exercise.