### PR TITLE
Add inline plot instruction for Keras Student Admission lab

### DIFF
--- a/lessons/DeepLearning/2_Keras/StudentAdmissionsKeras.ipynb
+++ b/lessons/DeepLearning/2_Keras/StudentAdmissionsKeras.ipynb
@@ -154,6 +154,17 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Importing matplotlib\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
    "outputs": [
@@ -169,9 +180,6 @@
     }
    ],
    "source": [
-    "# Importing matplotlib\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
     "# Function to help us plot\n",
     "def plot_points(data):\n",
     "    X = np.array(data[[\"gre\",\"gpa\"]])\n",


### PR DESCRIPTION
Avoid this output `<Figure size 640x480 with 1 Axes>` for the first plot by instructing Jupyter to plot inline.