### PR TITLE
updating deprecated import sklearn.cross_validation

### DIFF
--- a/projects/p1_charityml/finding_donors.ipynb
+++ b/projects/p1_charityml/finding_donors.ipynb
@@ -334,7 +334,7 @@
     "print(\"{} total features after one-hot encoding.\".format(len(encoded)))\n",
     "\n",
     "# Uncomment the following line to see the encoded feature names\n",
-    "# print encoded"
+    "# print(encoded)"
    ]
   },
   {

--- a/projects/p1_charityml/finding_donors.ipynb
+++ b/projects/p1_charityml/finding_donors.ipynb
@@ -356,7 +356,7 @@
    "outputs": [],
    "source": [
     "# Import train_test_split\n",
-    "from sklearn.cross_validation import train_test_split\n",
+    "from sklearn.model_selection import train_test_split\n",
     "\n",
     "# Split the 'features' and 'income' data into training and testing sets\n",
     "X_train, X_test, y_train, y_test = train_test_split(features_final, \n",


### PR DESCRIPTION
sklearn.cross_validation is deprecated (https://stackoverflow.com/questions/43302400/deprecation-warnings-from-sklearn)
so using sklearn.model_selection for importing train_test_split (https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.train_test_split.html)